### PR TITLE
Adding M1 support, fixing imgui crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ compile_commands.json
 .cache/
 out/
 vcpkg_installed
+build/
+CMakeFiles/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ option(GLFW_BUILD_DOCS OFF)
 option(GLFW_BUILD_EXAMPLES OFF)
 option(GLFW_BUILD_TESTS OFF)
 
+# Hardcode the architecture to arm64 on macOS
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+    set(CMAKE_OSX_ARCHITECTURES "arm64")
+endif()
+
 # set(CMAKE_TOOLCHAIN_FILE $ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
 # find_package(glfw3 CONFIG REQUIRED)
 include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)

--- a/src/chess/Chess.cpp
+++ b/src/chess/Chess.cpp
@@ -64,6 +64,7 @@ namespace Chess
 	void Chess::OnDetach()
 	{
         m_GameClient->Stop();
+        m_GameClientThread.join();
 	}
 
 	void Chess::OnPause()

--- a/src/chess/Chess.cpp
+++ b/src/chess/Chess.cpp
@@ -55,7 +55,7 @@ namespace Chess
 
 	void Chess::OnAttach()
 	{
-        m_GameClientThread = std::jthread([this]()
+        m_GameClientThread = std::thread([this]()
                                           {
                                                 m_GameClient->Start();
                                           });

--- a/src/chess/Chess.h
+++ b/src/chess/Chess.h
@@ -29,7 +29,7 @@ namespace Chess
 	private:
         Schism::GameEvent::CallbackBus m_NetworkSendBus;
         Schism::GameEvent::CallbackBus m_NetworkReceiveBus;
-        std::jthread m_GameClientThread;
+        std::thread m_GameClientThread;
 		Core::Assets m_Assets;
 		BoardRenderer m_BoardRenderer;
 		std::shared_ptr<Game> m_Game;

--- a/src/schism/Core/Application.cpp
+++ b/src/schism/Core/Application.cpp
@@ -18,9 +18,10 @@ namespace Schism
 	Application::Application(int w, int h, const char* name)
 	{
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 		glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
+		glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+		
 		Ref<Core::Window> Window = MakeRef<Core::Window>();
 
 		

--- a/src/schism/Gl/IndexBuffer.cpp
+++ b/src/schism/Gl/IndexBuffer.cpp
@@ -4,20 +4,20 @@ namespace Schism::Gl
 {
 	IndexBuffer::IndexBuffer()
 	{
-		glCreateBuffers(1, &m_BufferID);
+		glGenBuffers(1, &m_BufferID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
 	}
 
 	IndexBuffer::IndexBuffer(uint32_t* indices, uint32_t count)
 	{
-		glCreateBuffers(1, &m_BufferID);
+		glGenBuffers(1, &m_BufferID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
 		glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_DYNAMIC_DRAW);
 	}
 
 	IndexBuffer::IndexBuffer(std::vector<uint32_t>& indices)
 	{
-		glCreateBuffers(1, &m_BufferID);
+		glGenBuffers(1, &m_BufferID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
 		glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint32_t), &indices[0], GL_DYNAMIC_DRAW);
 	}

--- a/src/schism/Gl/IndexBuffer.h
+++ b/src/schism/Gl/IndexBuffer.h
@@ -28,7 +28,7 @@ namespace Schism::Gl
 	private:
 		void CreateBuffer()
 		{
-			glCreateBuffers(1, &m_BufferID);
+			glGenBuffers(1, &m_BufferID);
 			// Used GL_ARRAY_BUFFER so i can load data without an active VAO
 			glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
 		}

--- a/src/schism/Gl/VertexArray.cpp
+++ b/src/schism/Gl/VertexArray.cpp
@@ -4,7 +4,7 @@ namespace Schism::Gl
 {
 	VertexArray::VertexArray()
 	{
-		glCreateVertexArrays(1, &m_ID);
+		glGenVertexArrays(1, &m_ID);
 	}
 
 	VertexArray::~VertexArray()

--- a/src/schism/Gl/VertexBuffer.cpp
+++ b/src/schism/Gl/VertexBuffer.cpp
@@ -7,7 +7,7 @@ namespace Schism::Gl
 {
 	void VertexBuffer::CreateBuffer()
 	{
-		glCreateBuffers(1, &m_BufferID);
+		glGenBuffers(1, &m_BufferID);
 		glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
 	}
 

--- a/src/schism/Renderer/Texture.cpp
+++ b/src/schism/Renderer/Texture.cpp
@@ -7,13 +7,14 @@ namespace Schism::Renderer
 {
 	Texture::Texture()
 	{
-		glCreateTextures(GL_TEXTURE_2D, 1, &m_TextureID);
+		glGenTextures( 1, &m_TextureID);
+		glBindTexture(GL_TEXTURE_2D, m_TextureID);
 
-		glTextureParameteri(m_TextureID, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTextureParameteri(m_TextureID, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(m_TextureID, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(m_TextureID, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-		glTextureParameteri(m_TextureID, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTextureParameteri(m_TextureID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		glTexParameteri(m_TextureID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(m_TextureID, GL_TEXTURE_WRAP_T, GL_REPEAT);
 	}
 
 	Texture::Texture(const std::string& path, bool pixelart)
@@ -37,7 +38,7 @@ namespace Schism::Renderer
 			m_Format = GL_RGBA;
 		}
 
-		glCreateTextures(GL_TEXTURE_2D, 1, &m_TextureID);
+		glGenTextures(1, &m_TextureID);
 		glBindTexture(GL_TEXTURE_2D, m_TextureID);
 
 
@@ -48,11 +49,11 @@ namespace Schism::Renderer
 			filtering = GL_NEAREST;
 		}
 
-		glTextureParameteri(m_TextureID, GL_TEXTURE_MIN_FILTER, filtering);
-		glTextureParameteri(m_TextureID, GL_TEXTURE_MAG_FILTER, filtering);
+		glTexParameteri(m_TextureID, GL_TEXTURE_MIN_FILTER, filtering);
+		glTexParameteri(m_TextureID, GL_TEXTURE_MAG_FILTER, filtering);
 
-		glTextureParameteri(m_TextureID, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTextureParameteri(m_TextureID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		glTexParameteri(m_TextureID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(m_TextureID, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
 		// Can be done with glTextureSubImage2D
 		//glTextureSubImage2D(GL_TEXTURE_2D, 0, 0, 0, m_Width, m_Height, m_Format, GL_UNSIGNED_BYTE, data);

--- a/src/schism/Sandbox/SampleScene.cpp
+++ b/src/schism/Sandbox/SampleScene.cpp
@@ -103,7 +103,7 @@ void EditTransform(const Renderer::OrthographicCamera& camera, const glm::mat4& 
     static bool useSnap(false);
     if (ImGui::IsKeyPressed(ImGuiKey_S))
         useSnap = !useSnap;
-    ImGui::Checkbox("", &useSnap);
+    ImGui::Checkbox("Use Snap", &useSnap);
     ImGui::SameLine();
     ImGuiIO& io = ImGui::GetIO();
     ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
@@ -133,6 +133,7 @@ void SampleScene::OnDraw()
 		const auto& [transfrom, sprite] = m_Registry.get<Components::Transform2D, Components::Sprite>(e);
         const glm::mat4 mat = glm::translate(glm::mat4(1.f), transfrom.position);
         ImGuizmo::SetID(i);
+
         // ImGuizmo::DrawCubes(glm::value_ptr(m_Camera.GetViewMatrix()), glm::value_ptr(m_Camera.GetProjectionMatrix()), glm::value_ptr(mat), 1);
 		m_Renderer.Draw(transfrom, sprite, m_Camera.GetViewProjectionMatrix());
         EditTransform(m_Camera, mat, transfrom);


### PR DESCRIPTION
This PR adds support for Mac M1 by updating the OpenGL API calls to a lower, supported OpenGL version (4.0), and fixes a crash in imgui by adding a label.