### PR TITLE
Postpone window event adapter assertion

### DIFF
--- a/src/schism/Core/Window.cpp
+++ b/src/schism/Core/Window.cpp
@@ -68,11 +68,10 @@ void Window::HookGLFWEventFunctions() {
 }
 
 void Window::HookMouseEvents() {
-    SC_ASSERT(m_Data.eventManager, "There is no attached EventManager");
-
     glfwSetScrollCallback(
         m_WindowPtr, [](GLFWwindow* win, double xoffset, double yoffset) {
             auto data = static_cast<WindowData*>(glfwGetWindowUserPointer(win));
+            SC_ASSERT(data->eventAdapter, "There is no attached EventAdapter");
             data->eventAdapter->OnEvent(MouseScrollEvent(xoffset, yoffset));
         });
 
@@ -85,6 +84,8 @@ void Window::HookMouseEvents() {
         }
 
         auto data = static_cast<WindowData*>(glfwGetWindowUserPointer((win)));
+
+        SC_ASSERT(data->eventAdapter, "There is no attached EventAdapter");
 
         double xpos;
         double ypos;
@@ -105,29 +106,31 @@ void Window::HookMouseEvents() {
     glfwSetCursorPosCallback(m_WindowPtr, [](GLFWwindow* win, double xpos,
                                              double ypos) {
         auto data = static_cast<WindowData*>(glfwGetWindowUserPointer((win)));
+        SC_ASSERT(data->eventAdapter, "There is no attached EventAdapter");
         data->eventAdapter->OnEvent(MouseMoveEvent(xpos, ypos));
     });
 }
 
 void Window::HookWindowEvents() {
-    SC_ASSERT(m_Data.eventManager, "There is no attached EventManager");
     glfwSetWindowSizeCallback(m_WindowPtr, [](GLFWwindow* win, int width,
                                               int height) {
         auto data = static_cast<WindowData*>(glfwGetWindowUserPointer((win)));
+        SC_ASSERT(data->eventAdapter, "There is no attached EventAdapter");
         data->eventAdapter->OnEvent(WindowResizeEvent(width, height));
     });
 
     glfwSetWindowCloseCallback(m_WindowPtr, [](GLFWwindow* win) {
         auto data = static_cast<WindowData*>(glfwGetWindowUserPointer((win)));
+        SC_ASSERT(data->eventAdapter, "There is no attached EventAdapter");
         data->eventAdapter->OnEvent(WindowCloseEvent());
     });
 }
 
 void Window::HookKeyEvents() {
-    SC_ASSERT(m_Data.eventManager, "There is no attached EventManager");
     glfwSetKeyCallback(m_WindowPtr, [](GLFWwindow* win, int key, int scancode,
                                        int action, int mods) {
         auto data = static_cast<WindowData*>(glfwGetWindowUserPointer((win)));
+        SC_ASSERT(data->eventAdapter, "There is no attached EventAdapter");
         if (action == GLFW_PRESS) {
             data->eventAdapter->OnEvent(KeyDownEvent((Keyboard::Key)key));
         } else if (action == GLFW_RELEASE) {


### PR DESCRIPTION
This fixes two bugs one is that it window data only has `eventAdapter` so it does not compile and the second is that the previous implementation asserted that the adapter had been set when the events were being registered in GLFW.

This caused it to crash because the adapter is registered after the GLFW event handlers are registered.

This only temporary fix for the issue, if an event is triggered during registration but before adapter assignment this will fail.
